### PR TITLE
Fixes feature detection

### DIFF
--- a/src/_implementation/feature_detect.ts
+++ b/src/_implementation/feature_detect.ts
@@ -4,15 +4,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+// lib.dom.ts is out of date, so declare our own parseFromString here.
+interface DOMParser {
+  parseFromString(string: string, type: DOMParserSupportedType, options?: {
+    includeShadowRoots: boolean;
+  }): Document;
+}
+
 // This isn't ideal. Setting .innerHTML is not compatible with some
 // TrustedTypes CSP policies. Discussion at:
 //     https://github.com/mfreed7/declarative-shadow-dom/issues/3
 let hasNative: boolean|undefined;
 export function hasNativeDeclarativeShadowRoots(): boolean {
   if (hasNative === undefined) {
-    const div = document.createElement('div');
-    div.innerHTML = `<div><template shadowroot="open"></template></div>`;
-    hasNative = !!div.firstElementChild!.shadowRoot;
+    const html = `<div><template shadowroot="open"></template></div>`;
+    const fragment = (new DOMParser() as DOMParser).parseFromString(html, 'text/html', {
+      includeShadowRoots: true
+    });
+    hasNative = !!fragment.querySelector('div')?.shadowRoot;
   }
   return hasNative;
 }


### PR DESCRIPTION
Fixes #21

You can't use `innerHTML` to detect declarative root support because innerHTML does not attach shadow roots. Instead DOMParser must be used. This article describes the problem: https://web.dev/declarative-shadow-dom/#parser-only

Tested and verified in my project.