### PR TITLE
Update to remove warning

### DIFF
--- a/src/_implementation/feature_detect.ts
+++ b/src/_implementation/feature_detect.ts
@@ -18,9 +18,14 @@ let hasNative: boolean|undefined;
 export function hasNativeDeclarativeShadowRoots(): boolean {
   if (hasNative === undefined) {
     const html = `<div><template shadowrootmode="open"></template></div>`;
-    const fragment = (new DOMParser() as DOMParser).parseFromString(html, 'text/html', {
-      includeShadowRoots: true
-    });
+    let fragment: Document;
+    if ('parseHTMLUnsafe' in Document) {
+      fragment = (Document as { parseHTMLUnsafe: (html: string) => Document }).parseHTMLUnsafe(html);
+    } else {
+      fragment = (new DOMParser() as DOMParser).parseFromString(html, 'text/html', {
+        includeShadowRoots: true
+      });
+    }
     hasNative = !!fragment.querySelector('div')?.shadowRoot;
   }
   return hasNative;


### PR DESCRIPTION
This PR is in response to this error message:

```
[Deprecation] The includeShadowRoots parameter to parseFromString has been deprecated and removed. Please use parseHTMLUnsafe() or setHTMLUnsafe() instead.
```

Deprecation Notes: https://chromestatus.com/feature/5116094370283520

Closes #49 